### PR TITLE
feat: custom target db

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 #### Import a remote MySQL database
 
 ```bash
-ddev import-remote-db --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>]
+ddev import-remote-db --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>] [--target-db <target_db>]
 ```
 
 **Flags:**
@@ -41,17 +41,30 @@ ddev import-remote-db --host <host> --user <user> --database <database> [--port 
 | `--ssh-host` | SSH host for tunneling | No |
 | `--ssh-user` | SSH username | No |
 | `--password` | MySQL password | No (will prompt if not provided) |
+| `--target-db` | Target DDEV database name (default: db) | No |
 
-**Example:**
+**Examples:**
 
+Import a remote database into the default `db` database:
 ```bash
 ddev import-remote-db --host db.example.com --user dbuser --database dbname --port 3307 --ssh-host ssh.example.com --ssh-user remoteuser --password mypass
+```
+
+Import a remote database named `production_app_2024` into a local DDEV database named `db`:
+```bash
+ddev import-remote-db --host db.example.com --user dbuser --database production_app_2024 --target-db db
+```
+
+Import multiple remote databases into different target databases:
+```bash
+ddev import-remote-db --host db.example.com --user dbuser --database production_app_2024 --target-db db1
+ddev import-remote-db --host db.example.com --user dbuser --database legacy_records --target-db db2
 ```
 
 #### Import a remote MySQL database using 1Password
 
 ```bash
-ddev import-remote-db-1pw <1pw-item-uuid>
+ddev import-remote-db-1pw <1pw-item-uuid> [--target-db <target_db>]
 ```
 
 This command uses the [1Password CLI](https://developer.1password.com/docs/cli/get-started/) to securely fetch database credentials from your 1Password vault.
@@ -61,6 +74,12 @@ This command uses the [1Password CLI](https://developer.1password.com/docs/cli/g
 2. The script will fetch the database credentials and (optionally) SSH details from the 1Password item.
 3. You will be asked if SSH is required. If so, you can provide SSH host/user if not present in the item.
 4. The script will run `ddev import-remote-db` with the fetched credentials.
+
+**Flags:**
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--target-db` | Target DDEV database name (default: db) | No |
 
 **1Password Item Fields:**
 
@@ -75,10 +94,16 @@ The script will look for the following fields in your 1Password item (it tries m
 | SSH Host | `SSH_HOST` | No (prompted if SSH required) |
 | SSH Username | `SSH_USER` | No (prompted if SSH required) |
 
-**Example:**
+**Examples:**
 
+Import into the default `db` database:
 ```bash
 ddev import-remote-db-1pw 0198f64f-5ac6-79a5-8238-750890b87ce5
+```
+
+Import into a custom target database:
+```bash
+ddev import-remote-db-1pw 0198f64f-5ac6-79a5-8238-750890b87ce5 --target-db db1
 ```
 
 **Note:** The 1Password CLI (`op`) must be installed and you must be signed in. The script will check for this and prompt you if not.

--- a/commands/host/import-remote-db
+++ b/commands/host/import-remote-db
@@ -2,14 +2,15 @@
 
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 # Description: Import a remote MySQL database into DDEV
-# Usage: ddev import-remote-db --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>]
-# Example: ddev import-remote-db --host db.example.com --user dbuser --database dbname --port 3307 --ssh-host ssh.example.com --ssh-user remoteuser --password mypass
+# Usage: ddev import-remote-db --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>] [--target-db <target_db>]
+# Example: ddev import-remote-db --host db.example.com --user dbuser --database dbname --port 3307 --ssh-host ssh.example.com --ssh-user remoteuser --password mypass --target-db db
 
 set -e
 
 
 # Default values
 PORT=3306
+TARGET_DB="db"
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
@@ -43,13 +44,17 @@ while [[ $# -gt 0 ]]; do
       PASSWORD="$2"
       shift; shift
       ;;
+    --target-db)
+      TARGET_DB="$2"
+      shift; shift
+      ;;
     -h|--help)
-      echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>]"
+      echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>] [--target-db <target_db>]"
       exit 0
       ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>]"
+      echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>] [--target-db <target_db>]"
       exit 1
       ;;
   esac
@@ -61,7 +66,7 @@ DUMP_FILE="$EXPORT_DIR/${DATABASE}_remote_dump.sql"
 
 
 if [ -z "$HOST" ] || [ -z "$USER" ] || [ -z "$DATABASE" ]; then
-  echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>]"
+  echo "Usage: $0 --host <host> --user <user> --database <database> [--port <port>] [--ssh-host <ssh_host>] [--ssh-user <ssh_user>] [--password <password>] [--target-db <target_db>]"
   exit 1
 fi
 
@@ -136,7 +141,7 @@ else
   dump_and_clean
 fi
 
-echo "Importing $DUMP_FILE into DDEV..."
-ddev import-db --file="$DUMP_FILE"
+echo "Importing $DUMP_FILE into DDEV database '$TARGET_DB'..."
+ddev import-db --file="$DUMP_FILE" --target-db="$TARGET_DB"
 
 echo "Import complete."

--- a/commands/host/import-remote-db
+++ b/commands/host/import-remote-db
@@ -142,6 +142,6 @@ else
 fi
 
 echo "Importing $DUMP_FILE into DDEV database '$TARGET_DB'..."
-ddev import-db --file="$DUMP_FILE" --target-db="$TARGET_DB"
+ddev import-db --file="$DUMP_FILE" --database="$TARGET_DB"
 
 echo "Import complete."

--- a/commands/host/import-remote-db-1pw
+++ b/commands/host/import-remote-db-1pw
@@ -2,8 +2,36 @@
 
 # #ddev-generated: If you want to edit and own this file, remove this line.
 # Description: Import a remote MySQL database into DDEV using 1Password
-# Usage: ddev import-remote-db-1pw <1pw-item-uuid>
-# Example: ddev import-remote-db-1pw 0198f64f-5ac6-79a5-8238-750890b87ce5
+# Usage: ddev import-remote-db-1pw <1pw-item-uuid> [--target-db <target_db>]
+# Example: ddev import-remote-db-1pw 0198f64f-5ac6-79a5-8238-750890b87ce5 --target-db db
+
+# Default values
+TARGET_DB="db"
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --target-db)
+      TARGET_DB="$2"
+      shift; shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 <1pw-item-uuid> [--target-db <target_db>]"
+      echo "Example: $0 0198f64f-5ac6-79a5-8238-750890b87ce5 --target-db db"
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1"
+      echo "Usage: $0 <1pw-item-uuid> [--target-db <target_db>]"
+      exit 1
+      ;;
+    *)
+      ITEM_UUID="$1"
+      shift
+      ;;
+  esac
+done
 
 # Check if 1Password CLI is installed
 if ! command -v op >/dev/null 2>&1; then
@@ -12,9 +40,7 @@ if ! command -v op >/dev/null 2>&1; then
 fi
 
 # Use command line argument if provided, otherwise prompt user
-if [[ -n "$1" ]]; then
-  ITEM_UUID="$1"
-else
+if [[ -z "$ITEM_UUID" ]]; then
   read -p "Enter the 1Password item UUID: " ITEM_UUID
 fi
 
@@ -80,5 +106,5 @@ if [[ -z "$USER" || -z "$PASS" || -z "$DB" || -z "$HOST" ]]; then
   exit 1
 fi
 
-ddev import-remote-db --host "$HOST" --user "$USER" --database "$DB" --port "$PORT" --ssh-host "$SSH_HOST" --ssh-user "$SSH_USER" --password "$PASS"
+ddev import-remote-db --host "$HOST" --user "$USER" --database "$DB" --port "$PORT" --ssh-host "$SSH_HOST" --ssh-user "$SSH_USER" --password "$PASS" --target-db "$TARGET_DB"
 ddev tableplus

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -52,6 +52,28 @@ health_checks() {
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
 }
 
+@test "import-remote-db command accepts --target-db flag" {
+  set -eu -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  run ddev import-remote-db --help
+  assert_success
+  assert_output --partial "--target-db"
+}
+
+@test "import-remote-db-1pw command accepts --target-db flag" {
+  set -eu -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  run ddev import-remote-db-1pw --help
+  assert_success
+  assert_output --partial "--target-db"
+}
+
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1


### PR DESCRIPTION
## The Issue

Unable to specify target database name in ddev (defaults to 'db'). This results in problems for projects with more than 1 database.

## How This PR Solves The Issue

Added an optional flag `--target-db` where you can specify the target database name.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/esign/ddev-import-remote-db/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
This is a non breaking change since its an optional flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional --target-db flag to the import-remote-db and import-remote-db-1pw commands, allowing users to specify a custom target database name (defaults to "db").
  * Works with both SSH-based and 1Password-based import workflows.

* **Documentation**
  * Updated README with new usage examples demonstrating the target database option for various import scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->